### PR TITLE
add: add standard bm25 and transformer bm25 .

### DIFF
--- a/cranfield/standard_bm25.ipynb
+++ b/cranfield/standard_bm25.ipynb
@@ -1,0 +1,739 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Standard BM25\n",
+    "\n",
+    "Using the classic Cranfield dataset, this notebook shows how to use BM25 to calculate the similarity scores between a query and the documents and show the evaluation scores, i.e., precision and recall. Note that the ranking of the returned documents is not yet considered."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load data into dataframes\n",
+    "docs = pd.read_json(\"data/cranfield_docs.json\")\n",
+    "queries = pd.read_json(\"data/cranfield_queries.json\")\n",
+    "relevance = pd.read_json(\"data/cranfield_relevance.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>author</th>\n",
+       "      <th>bibliography</th>\n",
+       "      <th>body</th>\n",
+       "      <th>id</th>\n",
+       "      <th>title</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>brenckman,m.</td>\n",
+       "      <td>j. ae. scs. 25, 1958, 324.</td>\n",
+       "      <td>experimental investigation of the aerodynamics...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>experimental investigation of the aerodynamics...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>ting-yili</td>\n",
+       "      <td>department of aeronautical engineering, rensse...</td>\n",
+       "      <td>simple shear flow past a flat plate in an inco...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>simple shear flow past a flat plate in an inco...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>m. b. glauert</td>\n",
+       "      <td>department of mathematics, university of manch...</td>\n",
+       "      <td>the boundary layer in simple shear flow past a...</td>\n",
+       "      <td>3</td>\n",
+       "      <td>the boundary layer in simple shear flow past a...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>yen,k.t.</td>\n",
+       "      <td>j. ae. scs. 22, 1955, 728.</td>\n",
+       "      <td>approximate solutions of the incompressible la...</td>\n",
+       "      <td>4</td>\n",
+       "      <td>approximate solutions of the incompressible la...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>wasserman,b.</td>\n",
+       "      <td>j. ae. scs. 24, 1957, 924.</td>\n",
+       "      <td>one-dimensional transient heat conduction into...</td>\n",
+       "      <td>5</td>\n",
+       "      <td>one-dimensional transient heat conduction into...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          author                                       bibliography  \\\n",
+       "0   brenckman,m.                         j. ae. scs. 25, 1958, 324.   \n",
+       "1      ting-yili  department of aeronautical engineering, rensse...   \n",
+       "2  m. b. glauert  department of mathematics, university of manch...   \n",
+       "3       yen,k.t.                         j. ae. scs. 22, 1955, 728.   \n",
+       "4   wasserman,b.                         j. ae. scs. 24, 1957, 924.   \n",
+       "\n",
+       "                                                body  id  \\\n",
+       "0  experimental investigation of the aerodynamics...   1   \n",
+       "1  simple shear flow past a flat plate in an inco...   2   \n",
+       "2  the boundary layer in simple shear flow past a...   3   \n",
+       "3  approximate solutions of the incompressible la...   4   \n",
+       "4  one-dimensional transient heat conduction into...   5   \n",
+       "\n",
+       "                                               title  \n",
+       "0  experimental investigation of the aerodynamics...  \n",
+       "1  simple shear flow past a flat plate in an inco...  \n",
+       "2  the boundary layer in simple shear flow past a...  \n",
+       "3  approximate solutions of the incompressible la...  \n",
+       "4  one-dimensional transient heat conduction into...  "
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "docs.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>query</th>\n",
+       "      <th>query_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>what similarity laws must be obeyed when const...</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>what are the structural and aeroelastic proble...</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>what problems of heat conduction in composite ...</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>can a criterion be developed to show empirical...</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>what chemical kinetic system is applicable to ...</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                               query  query_id\n",
+       "0  what similarity laws must be obeyed when const...         1\n",
+       "1  what are the structural and aeroelastic proble...         2\n",
+       "2  what problems of heat conduction in composite ...         3\n",
+       "3  can a criterion be developed to show empirical...         4\n",
+       "4  what chemical kinetic system is applicable to ...         5"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "queries.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>query</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>query_id</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>what similarity laws must be obeyed when const...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>what are the structural and aeroelastic proble...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>what problems of heat conduction in composite ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>can a criterion be developed to show empirical...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>what chemical kinetic system is applicable to ...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                      query\n",
+       "query_id                                                   \n",
+       "1         what similarity laws must be obeyed when const...\n",
+       "2         what are the structural and aeroelastic proble...\n",
+       "3         what problems of heat conduction in composite ...\n",
+       "4         can a criterion be developed to show empirical...\n",
+       "5         what chemical kinetic system is applicable to ..."
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "queries.set_index('query_id', inplace=True)\n",
+    "queries.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'what similarity laws must be obeyed when constructing aeroelastic models of heated high speed aircraft .'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "queries['query'][1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>doc_id</th>\n",
+       "      <th>query_id</th>\n",
+       "      <th>r_score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>184</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>29</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>31</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>12</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>51</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   doc_id  query_id  r_score\n",
+       "0     184         1        2\n",
+       "1      29         1        2\n",
+       "2      31         1        2\n",
+       "3      12         1        3\n",
+       "4      51         1        3"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "relevance.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{1, 2, 3, 4}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "set(relevance['r_score'].values)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1400\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['experimental investigation of the aerodynamics of a wing in a slipstream .   an experimental study of a wing in a propeller slipstream was made in order to determine the spanwise distribution of the lift increase due to slipstream at different angles of attack of the wing and at different free stream to slipstream velocity ratios .  the results were intended in part as an evaluation basis for different theoretical treatments of this problem .   the comparative span loading curves, together with supporting evidence, showed that a substantial part of the lift increment produced by the slipstream was due to a /destalling/ or boundary-layer-control effect .  the integrated remaining lift increment, after subtracting this destalling lift, was found to agree well with a potential flow theory .   an empirical evaluation of the destalling effects was made for the specific configuration of the experiment .']"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "train_docs = docs['body'].tolist()\n",
+    "print(len(train_docs))\n",
+    "train_docs[:1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# https://tartarus.org/martin/PorterStemmer/def.txt\n",
+    "from nltk.stem.porter import PorterStemmer\n",
+    "porter_stemmer = PorterStemmer()\n",
+    "import re # regular expression\n",
+    "\n",
+    "\n",
+    "def stemming_tokenizer(str_input):\n",
+    "    words = re.sub(r\"[^A-Za-z\\-]\", \" \", str_input).lower().split() # delete non letter charactors\n",
+    "    #words = re.sub(r\"[^A-Za-z0-9\\-]\", \" \", str_input).lower().split() # include numbers\n",
+    "    words = [porter_stemmer.stem(word) for word in words]\n",
+    "    return words"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/tezign/anaconda3/lib/python3.7/site-packages/sklearn/feature_extraction/text.py:300: UserWarning: Your stop_words may be inconsistent with your preprocessing. Tokenizing the stop words generated tokens ['abov', 'afterward', 'alon', 'alreadi', 'alway', 'ani', 'anoth', 'anyon', 'anyth', 'anywher', 'becam', 'becaus', 'becom', 'befor', 'besid', 'cri', 'describ', 'dure', 'els', 'elsewher', 'empti', 'everi', 'everyon', 'everyth', 'everywher', 'fifti', 'formerli', 'forti', 'ha', 'henc', 'hereaft', 'herebi', 'hi', 'howev', 'hundr', 'inde', 'latterli', 'mani', 'meanwhil', 'moreov', 'mostli', 'nobodi', 'noon', 'noth', 'nowher', 'onc', 'onli', 'otherwis', 'ourselv', 'perhap', 'pleas', 'seriou', 'sever', 'sinc', 'sincer', 'sixti', 'someon', 'someth', 'sometim', 'somewher', 'themselv', 'thenc', 'thereaft', 'therebi', 'therefor', 'thi', 'thu', 'togeth', 'twelv', 'twenti', 'veri', 'wa', 'whatev', 'whenc', 'whenev', 'wherea', 'whereaft', 'wherebi', 'wherev', 'whi', 'yourselv'] not in stop_words.\n",
+      "  'stop_words.' % sorted(inconsistent))\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn.feature_extraction.text import CountVectorizer\n",
+    "\n",
+    "vectorizer = CountVectorizer(tokenizer=stemming_tokenizer, max_df=0.9, min_df=0.1, stop_words='english', ngram_range=(1, 3))\n",
+    "train_docs = vectorizer.fit_transform(train_docs)\n",
+    "train_docs = vectorizer.inverse_transform(train_docs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "from six import iteritems\n",
+    "from six.moves import xrange\n",
+    "\n",
+    "# BM25 parameters.\n",
+    "PARAM_K1 = 2.0\n",
+    "PARAM_B = 1.0\n",
+    "EPSILON = 0.25\n",
+    "\n",
+    "\n",
+    "class BM25(object):\n",
+    "\n",
+    "    def __init__(self, corpus):\n",
+    "        self.corpus_size = len(corpus)\n",
+    "        self.avgdl = sum(map(lambda x: float(len(x)), corpus)) / self.corpus_size\n",
+    "        self.corpus = corpus\n",
+    "        self.f = []\n",
+    "        self.df = {}\n",
+    "        self.idf = {}\n",
+    "        self.initialize()\n",
+    "        self.average_idf = self.get_average_idf()\n",
+    "\n",
+    "    def get_average_idf(self):\n",
+    "        return sum(map(lambda k: float(self.idf[k]), self.idf.keys())) / len(self.idf.keys())\n",
+    "\n",
+    "    def initialize(self):\n",
+    "        for document in self.corpus:\n",
+    "            frequencies = {}\n",
+    "            for word in document:\n",
+    "                if word not in frequencies:\n",
+    "                    frequencies[word] = 0\n",
+    "                frequencies[word] += 1\n",
+    "            self.f.append(frequencies)\n",
+    "\n",
+    "            for word, freq in iteritems(frequencies):\n",
+    "                if word not in self.df:\n",
+    "                    self.df[word] = 0\n",
+    "                self.df[word] += 1\n",
+    "\n",
+    "        for word, freq in iteritems(self.df):\n",
+    "            self.idf[word] = math.log(self.corpus_size - freq + 0.5) - math.log(freq + 0.5)\n",
+    "\n",
+    "    def get_score(self, document, index, average_idf):\n",
+    "        score = 0\n",
+    "        for word in document:\n",
+    "            if word not in self.f[index]:\n",
+    "                continue\n",
+    "            idf = self.idf[word] if self.idf[word] >= 0 else EPSILON * average_idf\n",
+    "            score += (idf * self.f[index][word] * (PARAM_K1 + 1)\n",
+    "                      / (self.f[index][word] + PARAM_K1 * (1 - PARAM_B + PARAM_B * self.corpus_size / self.avgdl)))\n",
+    "        return score\n",
+    "\n",
+    "    def get_scores(self, document):\n",
+    "        scores = []\n",
+    "        for index in xrange(self.corpus_size):\n",
+    "            score = self.get_score(document, index, self.average_idf)\n",
+    "            scores.append(score)\n",
+    "        return scores"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bm25 = BM25(train_docs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_doc_ids(query_id, similarity_threshold):\n",
+    "#     query = queries['query'][query_id]\n",
+    "#     query = vectorizer.transform([query])\n",
+    "#     query = vectorizer.inverse_transform(query)\n",
+    "    query = stemming_tokenizer(queries['query'][query_id])\n",
+    "    print(query)\n",
+    "    test_result = bm25.get_scores(query)\n",
+    "    max_score = max(test_result) if max(test_result) > 0 else 1\n",
+    "    test_result = [x / max_score for i, x in enumerate(test_result)]\n",
+    "    # pd.DataFrame(test_result.toarray())\n",
+    "    df = pd.DataFrame(test_result)  # calculate the pair-wise similarity and convert to df\n",
+    "    df = df.rename(columns={0: 'similarity'})  # rename the first column\n",
+    "    df = df.sort_values('similarity', ascending=False)  # sort the result based on similarity score\n",
+    "    df_filtered = df[df['similarity'] > similarity_threshold]  # filter the result based on similarity threshold\n",
+    "    returned_doc_ids_list = df_filtered.index.tolist()  # get the ids of the returned docs\n",
+    "    return returned_doc_ids_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get the doc ids with relevance score\n",
+    "# this is the ground truth of relevance docs for the query based on the human annotated data\n",
+    "def get_true_doc_ids(query_id, relevance_threshold):\n",
+    "    # filter based on r_score (1, 2, 3, or 4) and relevance_threshold\n",
+    "    true_doc_ids = relevance[(relevance['query_id'] == query_id) & (relevance['r_score'] <= relevance_threshold)]\n",
+    "    true_doc_ids_list = true_doc_ids['doc_id'].to_list()\n",
+    "    return true_doc_ids_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# calculate evaluation scores: precision and recall\n",
+    "\n",
+    "def show_eval_scores(returned_doc_ids_list, true_doc_ids_list):\n",
+    "    # true positive\n",
+    "    tp = [x for x in true_doc_ids_list if x in returned_doc_ids_list]\n",
+    "    # tp.sort()\n",
+    "    # print(tp, len(tp))\n",
+    "\n",
+    "    # false positive\n",
+    "    fp = [x for x in returned_doc_ids_list if x not in tp]\n",
+    "    # fp.sort()\n",
+    "    # print(fp, len(fp))\n",
+    "\n",
+    "    # false negative\n",
+    "    fn = [x for x in true_doc_ids_list if x not in tp]\n",
+    "    # fn.sort()\n",
+    "    # print(fn, len(fn))\n",
+    "\n",
+    "    precision = len(tp) / (len(tp) + len(fp))\n",
+    "    recall = len(tp) / (len(tp) + len(fn))\n",
+    "\n",
+    "    print(f'precision is {precision:.3%}')\n",
+    "    print(f'recall is {recall:.3%}')\n",
+    "\n",
+    "    return precision, recall"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# utility function to put everything together\n",
+    "def show_result(query_id, similarity_threshold, relevance_threshold):\n",
+    "    print(f\"query: {queries['query'][query_id]}\")\n",
+    "    print('calculating results......')\n",
+    "    # we set a similarity threshold and get the ids of those documents\n",
+    "    # similarity_threshold 0.65 is used in https://www.aaai.org/Papers/FLAIRS/2003/Flairs03-082.pdf\n",
+    "    returned_doc_ids_list = get_doc_ids(query_id, similarity_threshold)\n",
+    "\n",
+    "    # we choose relevance_threshold = 3, relevance 1, 2 and 3 mean relevant for returned documents\n",
+    "    # see readme for definitions about r_score\n",
+    "    true_doc_ids_list = get_true_doc_ids(query_id, relevance_threshold)\n",
+    "\n",
+    "    print(f'similarity_threshold is {similarity_threshold} and relevance_threshold is {relevance_threshold}')\n",
+    "\n",
+    "    show_eval_scores(returned_doc_ids_list, true_doc_ids_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "query: what similarity laws must be obeyed when constructing aeroelastic models of heated high speed aircraft .\n",
+      "calculating results......\n",
+      "['what', 'similar', 'law', 'must', 'be', 'obey', 'when', 'construct', 'aeroelast', 'model', 'of', 'heat', 'high', 'speed', 'aircraft']\n",
+      "similarity_threshold is 0.3 and relevance_threshold is 3\n",
+      "precision is 3.673%\n",
+      "recall is 40.909%\n"
+     ]
+    }
+   ],
+   "source": [
+    "# query_id = 1, similarity_threshold = 0.3, relevance_threshold = 3\n",
+    "show_result(1, 0.3, 3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "query: what are the structural and aeroelastic problems associated with flight of high speed aircraft .\n",
+      "calculating results......\n",
+      "['what', 'are', 'the', 'structur', 'and', 'aeroelast', 'problem', 'associ', 'with', 'flight', 'of', 'high', 'speed', 'aircraft']\n",
+      "similarity_threshold is 0.3 and relevance_threshold is 3\n",
+      "precision is 1.705%\n",
+      "recall is 28.571%\n"
+     ]
+    }
+   ],
+   "source": [
+    "# query_id = 2, similarity_threshold = 0.3, relevance_threshold = 3\n",
+    "show_result(2, 0.3, 3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/cranfield/transformer_bm25.ipynb
+++ b/cranfield/transformer_bm25.ipynb
@@ -1,0 +1,1029 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tansformer BM25\n",
+    "\n",
+    "Using the classic Cranfield dataset, this notebook shows how to use BM25 to calculate the similarity scores between a query and the documents and show the evaluation scores, i.e., precision and recall. Note that the ranking of the returned documents is not yet considered."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load data into dataframes\n",
+    "docs = pd.read_json(\"data/cranfield_docs.json\")\n",
+    "queries = pd.read_json(\"data/cranfield_queries.json\")\n",
+    "relevance = pd.read_json(\"data/cranfield_relevance.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>author</th>\n",
+       "      <th>bibliography</th>\n",
+       "      <th>body</th>\n",
+       "      <th>id</th>\n",
+       "      <th>title</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>brenckman,m.</td>\n",
+       "      <td>j. ae. scs. 25, 1958, 324.</td>\n",
+       "      <td>experimental investigation of the aerodynamics...</td>\n",
+       "      <td>1</td>\n",
+       "      <td>experimental investigation of the aerodynamics...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>ting-yili</td>\n",
+       "      <td>department of aeronautical engineering, rensse...</td>\n",
+       "      <td>simple shear flow past a flat plate in an inco...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>simple shear flow past a flat plate in an inco...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>m. b. glauert</td>\n",
+       "      <td>department of mathematics, university of manch...</td>\n",
+       "      <td>the boundary layer in simple shear flow past a...</td>\n",
+       "      <td>3</td>\n",
+       "      <td>the boundary layer in simple shear flow past a...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>yen,k.t.</td>\n",
+       "      <td>j. ae. scs. 22, 1955, 728.</td>\n",
+       "      <td>approximate solutions of the incompressible la...</td>\n",
+       "      <td>4</td>\n",
+       "      <td>approximate solutions of the incompressible la...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>wasserman,b.</td>\n",
+       "      <td>j. ae. scs. 24, 1957, 924.</td>\n",
+       "      <td>one-dimensional transient heat conduction into...</td>\n",
+       "      <td>5</td>\n",
+       "      <td>one-dimensional transient heat conduction into...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          author                                       bibliography  \\\n",
+       "0   brenckman,m.                         j. ae. scs. 25, 1958, 324.   \n",
+       "1      ting-yili  department of aeronautical engineering, rensse...   \n",
+       "2  m. b. glauert  department of mathematics, university of manch...   \n",
+       "3       yen,k.t.                         j. ae. scs. 22, 1955, 728.   \n",
+       "4   wasserman,b.                         j. ae. scs. 24, 1957, 924.   \n",
+       "\n",
+       "                                                body  id  \\\n",
+       "0  experimental investigation of the aerodynamics...   1   \n",
+       "1  simple shear flow past a flat plate in an inco...   2   \n",
+       "2  the boundary layer in simple shear flow past a...   3   \n",
+       "3  approximate solutions of the incompressible la...   4   \n",
+       "4  one-dimensional transient heat conduction into...   5   \n",
+       "\n",
+       "                                               title  \n",
+       "0  experimental investigation of the aerodynamics...  \n",
+       "1  simple shear flow past a flat plate in an inco...  \n",
+       "2  the boundary layer in simple shear flow past a...  \n",
+       "3  approximate solutions of the incompressible la...  \n",
+       "4  one-dimensional transient heat conduction into...  "
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "docs.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>query</th>\n",
+       "      <th>query_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>what similarity laws must be obeyed when const...</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>what are the structural and aeroelastic proble...</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>what problems of heat conduction in composite ...</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>can a criterion be developed to show empirical...</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>what chemical kinetic system is applicable to ...</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                               query  query_id\n",
+       "0  what similarity laws must be obeyed when const...         1\n",
+       "1  what are the structural and aeroelastic proble...         2\n",
+       "2  what problems of heat conduction in composite ...         3\n",
+       "3  can a criterion be developed to show empirical...         4\n",
+       "4  what chemical kinetic system is applicable to ...         5"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "queries.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>query</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>query_id</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>what similarity laws must be obeyed when const...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>what are the structural and aeroelastic proble...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>what problems of heat conduction in composite ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>can a criterion be developed to show empirical...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>what chemical kinetic system is applicable to ...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                      query\n",
+       "query_id                                                   \n",
+       "1         what similarity laws must be obeyed when const...\n",
+       "2         what are the structural and aeroelastic proble...\n",
+       "3         what problems of heat conduction in composite ...\n",
+       "4         can a criterion be developed to show empirical...\n",
+       "5         what chemical kinetic system is applicable to ..."
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "queries.set_index('query_id', inplace=True)\n",
+    "queries.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'what similarity laws must be obeyed when constructing aeroelastic models of heated high speed aircraft .'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "queries['query'][1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>doc_id</th>\n",
+       "      <th>query_id</th>\n",
+       "      <th>r_score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>184</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>29</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>31</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>12</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>51</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   doc_id  query_id  r_score\n",
+       "0     184         1        2\n",
+       "1      29         1        2\n",
+       "2      31         1        2\n",
+       "3      12         1        3\n",
+       "4      51         1        3"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "relevance.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{1, 2, 3, 4}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "set(relevance['r_score'].values)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1400\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['experimental investigation of the aerodynamics of a wing in a slipstream .   an experimental study of a wing in a propeller slipstream was made in order to determine the spanwise distribution of the lift increase due to slipstream at different angles of attack of the wing and at different free stream to slipstream velocity ratios .  the results were intended in part as an evaluation basis for different theoretical treatments of this problem .   the comparative span loading curves, together with supporting evidence, showed that a substantial part of the lift increment produced by the slipstream was due to a /destalling/ or boundary-layer-control effect .  the integrated remaining lift increment, after subtracting this destalling lift, was found to agree well with a potential flow theory .   an empirical evaluation of the destalling effects was made for the specific configuration of the experiment .']"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "train_docs = docs['body'].tolist()\n",
+    "print(len(train_docs))\n",
+    "train_docs[:1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# https://tartarus.org/martin/PorterStemmer/def.txt\n",
+    "from nltk.stem.porter import PorterStemmer\n",
+    "porter_stemmer = PorterStemmer()\n",
+    "import re # regular expression\n",
+    "\n",
+    "\n",
+    "def stemming_tokenizer(str_input):\n",
+    "    words = re.sub(r\"[^A-Za-z\\-]\", \" \", str_input).lower().split() # delete non letter charactors\n",
+    "    #words = re.sub(r\"[^A-Za-z0-9\\-]\", \" \", str_input).lower().split() # include numbers\n",
+    "    words = [porter_stemmer.stem(word) for word in words]\n",
+    "    return words"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import absolute_import, division, print_function, unicode_literals\n",
+    "import numpy as np\n",
+    "import scipy.sparse as sp\n",
+    "from sklearn.base import BaseEstimator, TransformerMixin\n",
+    "from sklearn.utils.validation import check_is_fitted\n",
+    "from sklearn.feature_extraction.text import _document_frequency\n",
+    "\n",
+    "class BM25Transformer(BaseEstimator, TransformerMixin):\n",
+    "    \"\"\"\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    use_idf : boolean, optional (default=True)\n",
+    "    k1 : float, optional (default=2.0)\n",
+    "    b : float, optional (default=0.75)\n",
+    "    References\n",
+    "    ----------\n",
+    "    Okapi BM25: a non-binary model - Introduction to Information Retrieval\n",
+    "    http://nlp.stanford.edu/IR-book/html/htmledition/okapi-bm25-a-non-binary-model-1.html\n",
+    "    \"\"\"\n",
+    "    def __init__(self, use_idf=True, k1=2.0, b=0.75):\n",
+    "        self.use_idf = use_idf\n",
+    "        self.k1 = k1\n",
+    "        self.b = b\n",
+    "\n",
+    "    def fit(self, X):\n",
+    "        \"\"\"\n",
+    "        Parameters\n",
+    "        ----------\n",
+    "        X : sparse matrix, [n_samples, n_features]\n",
+    "            document-term matrix\n",
+    "        \"\"\"\n",
+    "        if not sp.issparse(X):\n",
+    "            X = sp.csc_matrix(X)\n",
+    "        if self.use_idf:\n",
+    "            n_samples, n_features = X.shape\n",
+    "            df = _document_frequency(X)\n",
+    "            idf = np.log((n_samples - df + 0.5) / (df + 0.5))\n",
+    "            self._idf_diag = sp.spdiags(idf, diags=0, m=n_features, n=n_features)\n",
+    "        return self\n",
+    "\n",
+    "    def transform(self, X, copy=True):\n",
+    "        \"\"\"\n",
+    "        Parameters\n",
+    "        ----------\n",
+    "        X : sparse matrix, [n_samples, n_features]\n",
+    "            document-term matrix\n",
+    "        copy : boolean, optional (default=True)\n",
+    "        \"\"\"\n",
+    "        if hasattr(X, 'dtype') and np.issubdtype(X.dtype, np.float):\n",
+    "            # preserve float family dtype\n",
+    "            X = sp.csr_matrix(X, copy=copy)\n",
+    "        else:\n",
+    "            # convert counts or binary occurrences to floats\n",
+    "            X = sp.csr_matrix(X, dtype=np.float64, copy=copy)\n",
+    "\n",
+    "        n_samples, n_features = X.shape\n",
+    "\n",
+    "        # Document length (number of terms) in each row\n",
+    "        # Shape is (n_samples, 1)\n",
+    "        dl = X.sum(axis=1)\n",
+    "        # Number of non-zero elements in each row\n",
+    "        # Shape is (n_samples, )\n",
+    "        sz = X.indptr[1:] - X.indptr[0:-1]\n",
+    "        # In each row, repeat `dl` for `sz` times\n",
+    "        # Shape is (sum(sz), )\n",
+    "        # Example\n",
+    "        # -------\n",
+    "        # dl = [4, 5, 6]\n",
+    "        # sz = [1, 2, 3]\n",
+    "        # rep = [4, 5, 5, 6, 6, 6]\n",
+    "        rep = np.repeat(np.asarray(dl), sz)\n",
+    "        # Average document length\n",
+    "        # Scalar value\n",
+    "        avgdl = np.average(dl)\n",
+    "        # Compute BM25 score only for non-zero elements\n",
+    "        data = X.data * (self.k1 + 1) / (X.data + self.k1 * (1 - self.b + self.b * rep / avgdl))\n",
+    "        X = sp.csr_matrix((data, X.indices, X.indptr), shape=X.shape)\n",
+    "\n",
+    "        if self.use_idf:\n",
+    "            check_is_fitted(self, '_idf_diag', 'idf vector is not fitted')\n",
+    "\n",
+    "            expected_n_features = self._idf_diag.shape[0]\n",
+    "            if n_features != expected_n_features:\n",
+    "                raise ValueError(\"Input has n_features=%d while the model\"\n",
+    "                                 \" has been trained with n_features=%d\" % (\n",
+    "                                     n_features, expected_n_features))\n",
+    "            # *= doesn't work\n",
+    "            X = X * self._idf_diag\n",
+    "\n",
+    "        return X"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/tezign/anaconda3/lib/python3.7/site-packages/sklearn/feature_extraction/text.py:300: UserWarning: Your stop_words may be inconsistent with your preprocessing. Tokenizing the stop words generated tokens ['abov', 'afterward', 'alon', 'alreadi', 'alway', 'ani', 'anoth', 'anyon', 'anyth', 'anywher', 'becam', 'becaus', 'becom', 'befor', 'besid', 'cri', 'describ', 'dure', 'els', 'elsewher', 'empti', 'everi', 'everyon', 'everyth', 'everywher', 'fifti', 'formerli', 'forti', 'ha', 'henc', 'hereaft', 'herebi', 'hi', 'howev', 'hundr', 'inde', 'latterli', 'mani', 'meanwhil', 'moreov', 'mostli', 'nobodi', 'noon', 'noth', 'nowher', 'onc', 'onli', 'otherwis', 'ourselv', 'perhap', 'pleas', 'seriou', 'sever', 'sinc', 'sincer', 'sixti', 'someon', 'someth', 'sometim', 'somewher', 'themselv', 'thenc', 'thereaft', 'therebi', 'therefor', 'thi', 'thu', 'togeth', 'twelv', 'twenti', 'veri', 'wa', 'whatev', 'whenc', 'whenev', 'wherea', 'whereaft', 'wherebi', 'wherev', 'whi', 'yourselv'] not in stop_words.\n",
+      "  'stop_words.' % sorted(inconsistent))\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "BM25Transformer(b=0.75, k1=2.0, use_idf=True)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from sklearn.feature_extraction.text import CountVectorizer\n",
+    "\n",
+    "vectorizer = CountVectorizer(tokenizer=stemming_tokenizer, max_df=0.9, min_df=0.1, stop_words='english', ngram_range=(1, 3))\n",
+    "bm25_transformer = BM25Transformer(k1=2.0, b=0.75)\n",
+    "bm25_transformer.fit(vectorizer.fit_transform(train_docs))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/tezign/anaconda3/lib/python3.7/site-packages/ipykernel_launcher.py:49: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "      <th>1</th>\n",
+       "      <th>2</th>\n",
+       "      <th>3</th>\n",
+       "      <th>4</th>\n",
+       "      <th>5</th>\n",
+       "      <th>6</th>\n",
+       "      <th>7</th>\n",
+       "      <th>8</th>\n",
+       "      <th>9</th>\n",
+       "      <th>...</th>\n",
+       "      <th>120</th>\n",
+       "      <th>121</th>\n",
+       "      <th>122</th>\n",
+       "      <th>123</th>\n",
+       "      <th>124</th>\n",
+       "      <th>125</th>\n",
+       "      <th>126</th>\n",
+       "      <th>127</th>\n",
+       "      <th>128</th>\n",
+       "      <th>129</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.00000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2.021937</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.879272</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.058348</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.797763</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.00000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.580463</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.433954</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2.78382</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>3 rows × 130 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        0    1    2         3    4    5         6    7    8    9    ...  120  \\\n",
+       "0  0.000000  0.0  0.0  0.000000  0.0  0.0  0.000000  0.0  0.0  0.0  ...  0.0   \n",
+       "1  2.021937  0.0  0.0  0.879272  0.0  0.0  1.058348  0.0  0.0  0.0  ...  0.0   \n",
+       "2  0.000000  0.0  0.0  1.580463  0.0  0.0  0.000000  0.0  0.0  0.0  ...  0.0   \n",
+       "\n",
+       "   121       122  123  124  125  126  127  128      129  \n",
+       "0  0.0  0.000000  0.0  0.0  0.0  0.0  0.0  0.0  0.00000  \n",
+       "1  0.0  0.797763  0.0  0.0  0.0  0.0  0.0  0.0  0.00000  \n",
+       "2  0.0  1.433954  0.0  0.0  0.0  0.0  0.0  0.0  2.78382  \n",
+       "\n",
+       "[3 rows x 130 columns]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# testing data\n",
+    "# first sentence is the query\n",
+    "# rest are the documents\n",
+    "test_texts = [\n",
+    "    \"photo-thermoelastic investigation\",\n",
+    "    \"a simple model study of transient temperature and thermal stress distribution due to aerodynamic heating .   the present work is concerned with the determination of transient temperatures and thermal stresses in simple models intended to simulate parts or the whole of an aircraft structure of the built- up variety subjected to aerodynamic heating .   the first case considered is that of convective heat transfer into one side of a flat plate, representing a thick skin, and the effect of the resulting temperature distribution in inducing thermal stresses associated with bending restraint at the plate edges . numerical results are presented for the transient temperature differentials in the plate when the environment temperature first increases linearly with time and then remains constant, the period of linear increase representing the time of acceleration of the aircraft .  corresponding thermal stress information is presented .   the second case is that of the wide-flanged i-beam with convective heat transfer into the outer faces of the flanges .  numerical results are presented for transient temperature differentials for a wide range of values of the applicable parameters and for an environment temperature variation as described above . corresponding thermal stresses in a beam of infinite length are determined .  a theoretical analysis of the stress distribution in a beam of finite length is carried out and numerical results obtained for one case .\",\n",
+    "    \"photo-thermoelastic investigation of transient thermal stresses in a multiweb wing structure .   photothermoelastic experiments were performed on a long multiweb wing model for which a theoretical analysis is available in the literature .  the experimental procedures utilized to simulate the conditions prescribed in the theory are fully described .   correlation of theory and experiment in terms of dimensionless temperature, stress, time, and biot number revealed that the theory predicted values higher than the experimentally observed maximum thermal stresses at the center of the web .  \",\n",
+    "]\n",
+    "\n",
+    "test_X = vectorizer.transform(test_texts)\n",
+    "\n",
+    "test_result = bm25_transformer.transform(test_X)\n",
+    "pd.DataFrame(test_result.toarray())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "      <th>1</th>\n",
+       "      <th>2</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.136481</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "      <td>0.411099</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.136481</td>\n",
+       "      <td>0.411099</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          0         1         2\n",
+       "0  1.000000  0.000000  0.136481\n",
+       "1  0.000000  1.000000  0.411099\n",
+       "2  0.136481  0.411099  1.000000"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# cosine similarity for the testing data\n",
+    "from sklearn.metrics.pairwise import cosine_similarity \n",
+    "\n",
+    "test_similarity = cosine_similarity(test_result)\n",
+    "pd.DataFrame(test_similarity)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# given a query and similarity_thershold return the ids of docs\n",
+    "# this is the relevant docs that based on bm25 algorithm for the query\n",
+    "def get_doc_ids(query_id, similarity_threshold):\n",
+    "    \n",
+    "    all_docs = train_docs.copy() # make a copy of all docs list\n",
+    "    all_docs.insert(0, queries['query'][query_id]) # inser the current query at the begining of the list\n",
+    "    \n",
+    "    test_result = bm25_transformer.transform(vectorizer.transform(all_docs)) # generate the tfidf matrix\n",
+    "    # pd.DataFrame(test_result.toarray())\n",
+    "    df = pd.DataFrame(cosine_similarity(test_result)) # calculate the pair-wise similarity and convert to df\n",
+    "    df = df.rename(columns = {0:'similarity'}) # rename the first column \n",
+    "    df = df.sort_values('similarity', ascending=False) # sort the result based on similarity score\n",
+    "    df_filtered = df[df['similarity']>similarity_threshold] # filter the result based on similarity threshold\n",
+    "    returned_doc_ids_list = df_filtered.index.tolist() # get the ids of the returned docs\n",
+    "    return returned_doc_ids_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get the doc ids with relevance score \n",
+    "# this is the ground truth of relevance docs for the query based on the human annotated data\n",
+    "def get_true_doc_ids(query_id, relevance_threshold):\n",
+    "    # filter based on r_score (1, 2, 3, or 4) and relevance_threshold\n",
+    "    true_doc_ids = relevance[(relevance['query_id']==query_id) & (relevance['r_score']<=relevance_threshold)]\n",
+    "    true_doc_ids_list = true_doc_ids['doc_id'].to_list()\n",
+    "    return true_doc_ids_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# calculate evaluation scores: precision and recall\n",
+    "\n",
+    "def show_eval_scores(returned_doc_ids_list, true_doc_ids_list):\n",
+    "    \n",
+    "    # true positive \n",
+    "    tp = [x for x in true_doc_ids_list if x in returned_doc_ids_list]\n",
+    "    #tp.sort()\n",
+    "    #print(tp, len(tp))\n",
+    "    \n",
+    "    # false positive\n",
+    "    fp = [x for x in returned_doc_ids_list if x not in tp]\n",
+    "    #fp.sort()\n",
+    "    #print(fp, len(fp))\n",
+    "    \n",
+    "    # false negative\n",
+    "    fn = [x for x in true_doc_ids_list if x not in tp]\n",
+    "    #fn.sort()\n",
+    "    #print(fn, len(fn))\n",
+    "    \n",
+    "    precision = len(tp)/(len(tp)+len(fp))\n",
+    "    recall = len(tp)/(len(tp)+len(fn))\n",
+    "\n",
+    "\n",
+    "    print(f'precision is {precision:.3%}')\n",
+    "    print(f'recall is {recall:.3%}')\n",
+    "    \n",
+    "    return precision, recall"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# utility function to put everything together\n",
+    "def show_result(query_id, similarity_threshold, relevance_threshold):\n",
+    "    \n",
+    "    print(f\"query: {queries['query'][query_id]}\")\n",
+    "    print('calculating results......')\n",
+    "    # we set a similarity threshold and get the ids of those documents\n",
+    "    # similarity_threshold 0.65 is used in https://www.aaai.org/Papers/FLAIRS/2003/Flairs03-082.pdf\n",
+    "    returned_doc_ids_list = get_doc_ids(query_id, similarity_threshold)\n",
+    "\n",
+    "    # we choose relevance_threshold = 3, relevance 1, 2 and 3 mean relevant for returned documents\n",
+    "    # see readme for definitions about r_score\n",
+    "    true_doc_ids_list = get_true_doc_ids(query_id, relevance_threshold)\n",
+    "\n",
+    "    print(f'similarity_threshold is {similarity_threshold} and relevance_threshold is {relevance_threshold}')\n",
+    "\n",
+    "    show_eval_scores(returned_doc_ids_list, true_doc_ids_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "query: what similarity laws must be obeyed when constructing aeroelastic models of heated high speed aircraft .\n",
+      "calculating results......\n",
+      "similarity_threshold is 0.3 and relevance_threshold is 3\n",
+      "precision is 22.581%\n",
+      "recall is 31.818%\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/tezign/anaconda3/lib/python3.7/site-packages/ipykernel_launcher.py:49: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# query_id = 1, similarity_threshold = 0.3, relevance_threshold = 3\n",
+    "show_result(1, 0.3, 3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "query: what are the structural and aeroelastic problems associated with flight of high speed aircraft .\n",
+      "calculating results......\n",
+      "similarity_threshold is 0.3 and relevance_threshold is 3\n",
+      "precision is 10.256%\n",
+      "recall is 19.048%\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/tezign/anaconda3/lib/python3.7/site-packages/ipykernel_launcher.py:49: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# query_id = 2, similarity_threshold = 0.3, relevance_threshold = 3\n",
+    "show_result(2, 0.3, 3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Building BM25 algorithm with two methods：
1. standard bm25
Build the algorithm using the standard BM25 computing structure and verify it on the dataset.
2. transformer bm25
Build the algorithm using transformer structure and verify it on the dataset.
repo links:
https://github.com/arosh/BM25Transformer/blob/master/bm25.py
API of this library inherits from sklearn.feature_extraction.text.TfidfTransformer.
